### PR TITLE
better error handling for stashcp, better method to find tools

### DIFF
--- a/bin/stashcp
+++ b/bin/stashcp
@@ -12,10 +12,14 @@ usage="$(basename "$0") [-d] [-r] [-h] -s <source> [-l <location to be copied to
 
 function getClose {
 	# for now, call Ilija's code, and hope that it is available nearby
-	export StashToolsDir=$(pwd)
-	echo $StashToolsDir
-	source setStashCache.sh 
-	echo "STASHPREFIX is $STASHPREFIX"
+        setStashCache=`which setStashCache.sh 2>&1 > /dev/null`
+        if [ $? -ne '0' ]; then
+          >&2 echo "Cannot find setStashCache.sh, setting to defaults"
+          echo "root://data.ci-connect.net"
+	  exit 1
+        else 	
+	  echo $STASHPREFIX
+	fi
 }
 
 debug=0


### PR DESCRIPTION
please review.

``` bash
[lincolnb@login01 bin]$ ./stashcp --closest
Cannot find setStashCache.sh, setting to defaults
root://data.ci-connect.net
[lincolnb@login01 bin]$ export foobar=$(./stashcp --closest)
Cannot find setStashCache.sh, setting to defaults
[lincolnb@login01 bin]$ echo $foobar
root://data.ci-connect.net
```
