### PR TITLE
Replacing string attributes which should be integers.

### DIFF
--- a/bin/stashcp
+++ b/bin/stashcp
@@ -385,24 +385,24 @@ if [ $isJob -eq 1 ]; then
 	condor_chirp set_job_attr_delayed Chirp_StashCp_Prefix \"$sourcePrefix\"
 	## http://stackoverflow.com/a/2317171
 	startString=$(printf ",%s" "${starts[@]}")
-	condor_chirp set_job_attr_delayed Chirp_StashCp_DLStart \"${startString:1:1020}\"
+	condor_chirp set_job_attr_delayed Chirp_StashCp_DLStart \"${startString:1}\"
 	nameString=$(printf ",%s" "${names[@]}")
 	condor_chirp set_job_attr_delayed Chirp_StashCp_FileName \"${nameString:1:1020}\"
 	sizeString=$(printf ",%s" "${sizes[@]}")
-	condor_chirp set_job_attr_delayed Chirp_StashCp_FileSize \"${sizeString:1:1020}\"
+	condor_chirp set_job_attr_delayed Chirp_StashCp_FileSize ${sizeString:1}
 	timeString=$(printf ",%s" "${times[@]}")
-	condor_chirp set_job_attr_delayed Chirp_StashCp_DlTimeMs \"${timeString:1:1020}\"
+	condor_chirp set_job_attr_delayed Chirp_StashCp_DlTimeMs ${timeString:1}
 	if [ $failoverfiles ]; then
 		fofString=$(printf ",%s" "${failoverfiles[@]}")
 		condor_chirp set_job_attr_delayed Chirp_StashCp_FailoverFiles \"${fofString:1:1020}\"
 		fotString=$(printf ",%s" "${failovertimes[@]}")
-		condor_chirp set_job_attr_delayed Chirp_StashCp_FailoverTimes \"${fotString:1:1020}\"
+		condor_chirp set_job_attr_delayed Chirp_StashCp_FailoverTimes ${fotString:1}
 	fi
 	if [ $failfiles ]; then
 		ffString=$(printf ",%s" "${failfiles[@]}")
 		condor_chirp set_job_attr_delayed Chirp_StashCp_FailFiles \"${ffString:1:1020}\"
 		ftString=$(printf ",%s" "${failtimes[@]}")
-		condor_chirp set_job_attr_delayed Chirp_StashCp_FailTimes \"${ftString:1:1020}\"
+		condor_chirp set_job_attr_delayed Chirp_StashCp_FailTimes ${ftString:1}
 		fcString=$(printf ",%s" "${failcodes[@]}")
 		condor_chirp set_job_attr_delayed Chirp_StashCp_FailCodes \"${fcString:1:1020}\"
 	fi


### PR DESCRIPTION
Many of the chirp attributes are being set as strings rather than
integers.  This makes parsing and filtering by these attributes
impossible.  The `Chirp_StashCp_DLStart` attribute cannot be converted
into an integer because it is too large for chirp, and it rolls over
to a negative number.
